### PR TITLE
Update hostname validation and error messages

### DIFF
--- a/imageroot/actions/configure-module/validate-input.json
+++ b/imageroot/actions/configure-module/validate-input.json
@@ -20,7 +20,8 @@
         "host": {
             "type": "string",
             "description": "Host name for the application, like 'kickstart.domain.org'",
-            "format": "idn-hostname"
+            "format": "hostname",
+            "pattern": "\\."
         },
         "lets_encrypt": {
             "type": "boolean",

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -32,7 +32,9 @@
     "advanced": "Advanced",
     "configuring": "Configuring",
     "instance_configuration": "Configure kickstart",
-    "domain_already_used_in_traefik": "Domain already used in traefik"
+    "domain_already_used_in_traefik": "Domain already used in traefik",
+    "host_pattern": "Must be a valid fully qualified domain name",
+    "host_format": "Must be a valid fully qualified domain name"
   },
   "about": {
     "title": "About"


### PR DESCRIPTION
This pull request updates the hostname validation in the `validate-input.json` file to use the `hostname` format and adds error messages for domain and host validation in the `translation.json` file.

https://github.com/NethServer/dev/issues/6853