### PR TITLE
Enable and restart kickstart.service

### DIFF
--- a/imageroot/actions/configure-module/80start_services
+++ b/imageroot/actions/configure-module/80start_services
@@ -13,4 +13,5 @@ exec 1>&2
 
 touch smarthost.env
 
-systemctl --user enable --now kickstart.service
+systemctl --user enable kickstart.service
+systemctl --user restart kickstart.service


### PR DESCRIPTION
This pull request enables and restarts the kickstart.service. Previously, the service was only enabled but not restarted. This change ensures that the service is both enabled and restarted, providing the necessary functionality.